### PR TITLE
Add `WKDataEnvironment` and `WKNetworkService` protocol

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "WKData",
+	platforms: [.iOS(.v14)],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "WKData",
-	platforms: [.iOS(.v14)],
+    platforms: [.iOS(.v14)],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(

--- a/Sources/WKData/Environment/WKDataEnvironment.swift
+++ b/Sources/WKData/Environment/WKDataEnvironment.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+public final class WKDataEnvironment: ObservableObject {
+
+	public static let current = WKDataEnvironment()
+
+	@Published public private(set) var mediaWikiNetworkService: WKNetworkService?
+
+}

--- a/Sources/WKData/Network/WKNetworkRequest.swift
+++ b/Sources/WKData/Network/WKNetworkRequest.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+public struct WKNetworkRequest {
+
+	public enum Method: String {
+		case GET
+		case POST
+		case PUT
+		case DELETE
+		case HEAD
+	}
+
+	public let url: URL?
+	public let method: Method
+	public let parameters: [String: Any]?
+
+}

--- a/Sources/WKData/Network/WKNetworkService.swift
+++ b/Sources/WKData/Network/WKNetworkService.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+public protocol WKNetworkService {
+	func perform(request: WKNetworkRequest, completion: @escaping (Result<[String: Any]?, Error>) -> Void)
+}

--- a/Sources/WKData/WKData.swift
+++ b/Sources/WKData/WKData.swift
@@ -1,6 +1,0 @@
-public struct WKData {
-    public private(set) var text = "Hello, World!"
-
-    public init() {
-    }
-}

--- a/Tests/WKDataTests/WKDataTests.swift
+++ b/Tests/WKDataTests/WKDataTests.swift
@@ -2,10 +2,4 @@ import XCTest
 @testable import WKData
 
 final class WKDataTests: XCTestCase {
-    func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct
-        // results.
-        XCTAssertEqual(WKData().text, "Hello, World!")
-    }
 }


### PR DESCRIPTION
This adds a `WKDataEnvironment` class akin to the `Components` framework's `WKAppEnvironment` for transiting app specific data to the `Data` framework. It also adds a `WKNetworkService` protocol that can be conformed to by a client app to support the `Data` framework performing authenticated requests via the client app's network infrastructure.

I anticipate both `WKNetworkService` and `WKNetworkRequest` will need to evolve as our required MediaWiki API request needs are surfaced by feature implementation.