### PR TITLE
Watchlist - add one year expiration period

### DIFF
--- a/Sources/WKData/Fetchers/WKWatchlistService.swift
+++ b/Sources/WKData/Fetchers/WKWatchlistService.swift
@@ -27,6 +27,7 @@ public enum WKWatchlistExpiryType: String {
     case oneMonth = "1 month"
     case threeMonths = "3 months"
     case sixMonths = "6 months"
+    case oneYear = "1 year"
 }
 
 public struct WKPageWatchStatus {


### PR DESCRIPTION
Adds a "1 year" option to `WKWatchlistExpiryType`. I have not tested this, but it appears it's supported and that "1 year" is also the default watch expiry period for MediaWiki versions 1.40+.