### PR TITLE
Allow empty Watchlist comments in API response

### DIFF
--- a/Sources/WKData/Fetchers/WKWatchlistService.swift
+++ b/Sources/WKData/Fetchers/WKWatchlistService.swift
@@ -52,8 +52,8 @@ fileprivate struct WatchlistAPIResponse: Codable {
             let isAnon: Bool
             let isBot: Bool
             let timestampString: String
-            let commentWikitext: String
-            let commentHtml: String
+            let commentWikitext: String?
+            let commentHtml: String?
             let byteLength: UInt
             let oldByteLength: UInt
             
@@ -188,7 +188,6 @@ public class WKWatchlistService {
                 
                 switch result {
                 case .success(let apiResponse):
-                    
                     if let apiResponseErrors = apiResponse.errors,
                        !apiResponseErrors.isEmpty {
                         errors.append(contentsOf: apiResponseErrors)
@@ -236,8 +235,8 @@ public class WKWatchlistService {
                 isAnon: item.isAnon,
                 isBot: item.isBot,
                 timestamp: timestamp,
-                commentWikitext: item.commentWikitext,
-                commentHtml: item.commentHtml,
+                commentWikitext: item.commentWikitext ?? "",
+                commentHtml: item.commentHtml ?? "",
                 byteLength: item.byteLength,
                 oldByteLength: item.oldByteLength,
                 project: project)

--- a/Sources/WKDataMocks/Resources/watchlist-get-list-en.json
+++ b/Sources/WKDataMocks/Resources/watchlist-get-list-en.json
@@ -161,7 +161,6 @@
         "oldlen": 5141,
         "newlen": 5209,
         "timestamp": "2023-05-19T22:41:00Z",
-        "comment": "",
         "parsedcomment": ""
       },
       {
@@ -179,8 +178,7 @@
         "oldlen": 5089,
         "newlen": 5141,
         "timestamp": "2023-05-19T22:40:24Z",
-        "comment": "",
-        "parsedcomment": ""
+        "comment": ""
       },
       {
         "type": "edit",
@@ -197,8 +195,6 @@
         "oldlen": 5018,
         "newlen": 5089,
         "timestamp": "2023-05-18T17:30:32Z",
-        "comment": "",
-        "parsedcomment": ""
       },
       {
         "type": "edit",


### PR DESCRIPTION
When watching today's featured EN article (https://en.wikipedia.org/wiki/Frances_Cleveland), I noticed that the Watchlist fetch was failing on decode. It appears that when `comment` and `parsedcomment` are empty, they may be missing from the API response (though I didn't inspect the raw responses). This PR makes those both optional from API responses, but persists an empty string for outward facing `WKWatchlist.Item` usage.

I also modified a bit of the EN test JSON to represent the three failure cases here: `comments` missing, `parsedcomments` missing, and both missing. Happy to change all this if you prefer an alternative or if I'm missing something.