### PR TITLE
Fix projects filter bug

### DIFF
--- a/Sources/WKData/Data Controllers/WKWatchlistDataController.swift
+++ b/Sources/WKData/Data Controllers/WKWatchlistDataController.swift
@@ -102,7 +102,7 @@ public class WKWatchlistDataController {
         
         let projects = onWatchlistProjects()
         guard !projects.isEmpty else {
-            completion(.failure(WKWatchlistError.failureDeterminingProjects))
+            completion(.success(WKWatchlist(items: [], activeFilterCount: offWatchlistProjects().count)))
             return
         }
         

--- a/Sources/WKData/Errors.swift
+++ b/Sources/WKData/Errors.swift
@@ -15,9 +15,3 @@ public enum WKUserDefaultsStoreError: Error {
     case failureDecodingJSON(Error)
     case failureEncodingJSON(Error)
 }
-
-// MARK: Feature-specific
-
-public enum WKWatchlistError: Error {
-    case failureDeterminingProjects
-}


### PR DESCRIPTION
https://phabricator.wikimedia.org/T342929

I needed this fix in order for filtering by projects to work. Without it, turning off all projects would result in an error and a missing activeFilterCount.