### PR TITLE
Watchlist Filters PR Feedback

### DIFF
--- a/Sources/WKData/Data Controllers/WKWatchlistDataController.swift
+++ b/Sources/WKData/Data Controllers/WKWatchlistDataController.swift
@@ -100,9 +100,11 @@ public class WKWatchlistDataController {
             return
         }
         
+        let activeFilterCount = self.activeFilterCount()
+        
         let projects = onWatchlistProjects()
         guard !projects.isEmpty else {
-            completion(.success(WKWatchlist(items: [], activeFilterCount: offWatchlistProjects().count)))
+            completion(.success(WKWatchlist(items: [], activeFilterCount: activeFilterCount)))
             return
         }
         
@@ -127,8 +129,6 @@ public class WKWatchlistDataController {
         projects.forEach { project in
             errors[project] = []
         }
-        
-        let activeFilterCount = self.activeFilterCount()
         
         for project in projects {
             

--- a/Sources/WKData/Data Controllers/WKWatchlistDataController.swift
+++ b/Sources/WKData/Data Controllers/WKWatchlistDataController.swift
@@ -239,7 +239,7 @@ public class WKWatchlistDataController {
     
     private func apply(filterSettings: WKWatchlistFilterSettings, to parameters: inout [String: String]) {
         switch filterSettings.latestRevisions {
-        case .all, .notTheLatestRevision:
+        case .notTheLatestRevision:
             parameters["wlallrev"] = "1"
         case .latestRevision:
             break

--- a/Sources/WKData/Models/WKWatchlistFilterSettings.swift
+++ b/Sources/WKData/Models/WKWatchlistFilterSettings.swift
@@ -3,7 +3,6 @@ import Foundation
 public struct WKWatchlistFilterSettings: Codable, Equatable {
 
     public enum LatestRevisions: Int, Codable {
-        case all
         case latestRevision
         case notTheLatestRevision
     }
@@ -59,7 +58,7 @@ public struct WKWatchlistFilterSettings: Codable, Equatable {
         self.offTypes = offTypes
     }
     
-    init(latestRevisions: WKWatchlistFilterSettings.LatestRevisions = .all, activity: WKWatchlistFilterSettings.Activity = .all, automatedContributions: WKWatchlistFilterSettings.AutomatedContributions = .all, significance: WKWatchlistFilterSettings.Significance = .all, userRegistration: WKWatchlistFilterSettings.UserRegistration = .all, offTypes: [WKWatchlistFilterSettings.ChangeType] = []) {
+    init(latestRevisions: WKWatchlistFilterSettings.LatestRevisions = .notTheLatestRevision, activity: WKWatchlistFilterSettings.Activity = .all, automatedContributions: WKWatchlistFilterSettings.AutomatedContributions = .all, significance: WKWatchlistFilterSettings.Significance = .all, userRegistration: WKWatchlistFilterSettings.UserRegistration = .all, offTypes: [WKWatchlistFilterSettings.ChangeType] = []) {
 
         self.offProjects = []
         self.latestRevisions = latestRevisions

--- a/Tests/WKDataTests/WKWatchlistDataControllerTests.swift
+++ b/Tests/WKDataTests/WKWatchlistDataControllerTests.swift
@@ -180,6 +180,38 @@ final class WKWatchlistDataControllerTests: XCTestCase {
         XCTAssertEqual(commonsItems.count, 3, "Incorrect number of commons watchlist items returned")
     }
     
+    func testFetchWatchlistWithAllProjectsPlusOneFilter() {
+        let controller = WKWatchlistDataController()
+        
+        let filterSettingsToSave = WKWatchlistFilterSettings(offProjects: [enProject, esProject, .wikidata, .commons], latestRevisions: .latestRevision, activity: .all, automatedContributions: .all, significance: .all, userRegistration: .all, offTypes: [])
+        controller.saveFilterSettings(filterSettingsToSave)
+        
+        let expectation = XCTestExpectation(description: "Fetch Watchlist")
+        
+        var watchlistToTest: WKWatchlist?
+        controller.fetchWatchlist { result in
+            switch result {
+            case .success(let watchlist):
+                
+                watchlistToTest = watchlist
+                
+            case .failure(let error):
+                XCTFail("Failure fetching watchlist: \(error)")
+            }
+            
+            expectation.fulfill()
+        }
+        
+        wait(for: [expectation], timeout: 10.0)
+        
+        guard let watchlistToTest else {
+            XCTFail("Missing watchlistToTest")
+            return
+        }
+        
+        XCTAssertEqual(watchlistToTest.activeFilterCount, 5, "Incorrect activeFilterCount")
+    }
+    
     func testFetchWatchlistWithBotsFilter() {
         let controller = WKWatchlistDataController()
         

--- a/Tests/WKDataTests/WKWatchlistDataControllerTests.swift
+++ b/Tests/WKDataTests/WKWatchlistDataControllerTests.swift
@@ -33,7 +33,7 @@ final class WKWatchlistDataControllerTests: XCTestCase {
     
     func testOnOffWatchlistProjects() {
         let controller = WKWatchlistDataController()
-        let filterSettingsToSave = WKWatchlistFilterSettings(offProjects: [.wikidata, .commons], latestRevisions: .all, activity: .all, automatedContributions: .all, significance: .all, userRegistration: .all, offTypes: [])
+        let filterSettingsToSave = WKWatchlistFilterSettings(offProjects: [.wikidata, .commons], latestRevisions: .notTheLatestRevision, activity: .all, automatedContributions: .all, significance: .all, userRegistration: .all, offTypes: [])
         controller.saveFilterSettings(filterSettingsToSave)
         XCTAssertEqual(controller.onWatchlistProjects(), [enProject, esProject])
         XCTAssertEqual(controller.offWatchlistProjects(), [.wikidata, .commons])
@@ -41,7 +41,7 @@ final class WKWatchlistDataControllerTests: XCTestCase {
     
     func testAllOffChangeTypes() {
         let controller = WKWatchlistDataController()
-        let filterSettingsToSave = WKWatchlistFilterSettings(offProjects: [], latestRevisions: .all, activity: .all, automatedContributions: .all, significance: .all, userRegistration: .all, offTypes: [.categoryChanges, .pageCreations])
+        let filterSettingsToSave = WKWatchlistFilterSettings(offProjects: [], latestRevisions: .notTheLatestRevision, activity: .all, automatedContributions: .all, significance: .all, userRegistration: .all, offTypes: [.categoryChanges, .pageCreations])
         controller.saveFilterSettings(filterSettingsToSave)
         XCTAssertEqual(controller.allChangeTypes(), [.pageEdits, .pageCreations, .categoryChanges, .wikidataEdits, .loggedActions])
         XCTAssertEqual(controller.offChangeTypes(), [.categoryChanges, .pageCreations])
@@ -140,7 +140,7 @@ final class WKWatchlistDataControllerTests: XCTestCase {
     func testFetchWatchlistWithProjectFilter() {
         let controller = WKWatchlistDataController()
         
-        let filterSettingsToSave = WKWatchlistFilterSettings(offProjects: [enProject, esProject], latestRevisions: .all, activity: .all, automatedContributions: .all, significance: .all, userRegistration: .all, offTypes: [])
+        let filterSettingsToSave = WKWatchlistFilterSettings(offProjects: [enProject, esProject], latestRevisions: .notTheLatestRevision, activity: .all, automatedContributions: .all, significance: .all, userRegistration: .all, offTypes: [])
         controller.saveFilterSettings(filterSettingsToSave)
         
         let expectation = XCTestExpectation(description: "Fetch Watchlist")
@@ -183,7 +183,7 @@ final class WKWatchlistDataControllerTests: XCTestCase {
     func testFetchWatchlistWithBotsFilter() {
         let controller = WKWatchlistDataController()
         
-        let filterSettingsToSave = WKWatchlistFilterSettings(offProjects: [], latestRevisions: .all, activity: .all, automatedContributions: .bot, significance: .all, userRegistration: .all, offTypes: [])
+        let filterSettingsToSave = WKWatchlistFilterSettings(offProjects: [], latestRevisions: .notTheLatestRevision, activity: .all, automatedContributions: .bot, significance: .all, userRegistration: .all, offTypes: [])
         controller.saveFilterSettings(filterSettingsToSave)
         
         let expectation = XCTestExpectation(description: "Fetch Watchlist")


### PR DESCRIPTION
Phab task: https://phabricator.wikimedia.org/T342929#9150414

This PR removes the "All" option for Watchlist filter settings. It also fixes a bug I found where the filter count would not increment if you had all projects off and additional filters below. Previously the count would max out to the project count.